### PR TITLE
Fix Home Assistant add-on slug mismatch

### DIFF
--- a/ptcgp_deck_analyze/config.json
+++ b/ptcgp_deck_analyze/config.json
@@ -1,7 +1,7 @@
 {
   "name": "Pokemon TCG Pocket Deck Analyzer",
-  "version": "1.0.5",
-  "slug": "pokemon_addon",
+  "version": "1.0.6",
+  "slug": "ptcgp_deck_analyze",
   "description": "分析 Pokemon TCG Pocket 牌組勝率的 Home Assistant Add-on",
   "startup": "once",
   "boot": "manual",


### PR DESCRIPTION
## Summary
- fix slug mismatch by matching folder name and update version

## Testing
- `python -m py_compile ptcgp_deck_analyze/scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_683fbc639d348333b516c22c776d3b0f