### PR TITLE
Fix OpenAI key usage

### DIFF
--- a/ptcgp_deck_analyze/scraper.py
+++ b/ptcgp_deck_analyze/scraper.py
@@ -64,6 +64,7 @@ if addon_options:
     except Exception as e:
         print("❌ 無法解析 HASSIO_ADDON_OPTIONS:", e)
 
+# openai 庫自 v1 起不再讀取全域變數，因此需在建立客戶端時傳入
 openai.api_key = openai_api_key
 
 logging.basicConfig(
@@ -369,7 +370,7 @@ def ask_chatgpt(deck_df: pd.DataFrame, matrix: Dict[str, Dict[str, Dict[str, Any
     )
 
     try:
-        client = openai.OpenAI()
+        client = openai.OpenAI(api_key=openai_api_key)
         response = client.chat.completions.create(
             model=CONFIG['CHATGPT']['MODEL'],
             messages=[


### PR DESCRIPTION
## Summary
- adjust comment about API key loading
- pass API key directly when creating the OpenAI client

## Testing
- `python ptcgp_deck_analyze/scraper.py` *(fails: Connection error)*

------
https://chatgpt.com/codex/tasks/task_e_684014e9ab84833396eb60eddd78c836