### PR TITLE
Fix Tapu spacing

### DIFF
--- a/ptcgp_deck_analyze/config.json
+++ b/ptcgp_deck_analyze/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Pokemon TCG Pocket Deck Analyzer",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "slug": "ptcgp_deck_analyze",
   "description": "分析 Pokemon TCG Pocket 牌組勝率的 Home Assistant Add-on",
   "startup": "once",

--- a/ptcgp_deck_analyze/scraper.py
+++ b/ptcgp_deck_analyze/scraper.py
@@ -1,6 +1,7 @@
 import os
 import json
 import logging
+import re
 import requests
 import pandas as pd
 import openai
@@ -143,9 +144,8 @@ class NameResolver:
     def get(self, english_name: str) -> str:
         if english_name in self.cache:
             return self.cache[english_name]
-        # 處理 Tapu 開頭的寶可夢
-        if english_name.startswith('Tapu'):
-            english_name = english_name.replace(' ', '')
+        # 處理 Tapu 後接空白的寶可夢名稱
+        english_name = re.sub(r'Tapu\s+(\w+)', r'Tapu\1', english_name)
         
         # 分割牌組名稱（通常是兩隻寶可夢）
         parts = english_name.split(' ')
@@ -452,9 +452,8 @@ if __name__ == '__main__':
 
 def get_pokemon_chinese_name(name: str) -> str:
     """Get Chinese name for a Pokemon deck name."""
-    # 處理 Tapu 開頭的寶可夢
-    if name.startswith('Tapu'):
-        name = name.replace(' ', '')
+    # 處理 Tapu 後接空白的寶可夢名稱
+    name = re.sub(r'Tapu\s+(\w+)', r'Tapu\1', name)
     
     # 分割牌組名稱（通常是兩隻寶可夢）
     parts = name.split(' ')


### PR DESCRIPTION
## Summary
- handle `Tapu` names with spaces when resolving deck names
- bump addon version to 1.0.14

## Testing
- `python -m py_compile ptcgp_deck_analyze/scraper.py`
- `python ptcgp_deck_analyze/scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_68405f07020c833399df1c5f0b5960de