### PR TITLE
Fix run.sh path error

### DIFF
--- a/ptcgp_deck_analyze/Dockerfile
+++ b/ptcgp_deck_analyze/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.18
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.18
+FROM ${BUILD_FROM}
 
 # 安裝 Python + 基本工具
 RUN apk add --no-cache python3 py3-pip
@@ -7,7 +8,7 @@ RUN apk add --no-cache python3 py3-pip
 RUN apk add --no-cache gcc musl-dev libffi-dev
 
 # 你的其他前置檔案
-COPY ptcgp_deck_analyze/requirements.txt /app/requirements.txt
+COPY requirements.txt /app/requirements.txt
 
 # 先更新 pip
 RUN pip install --upgrade pip
@@ -16,7 +17,7 @@ RUN pip install --upgrade pip
 RUN pip install -r /app/requirements.txt
 
 # 複製你的程式碼（如果有）
-COPY ptcgp_deck_analyze /app/ptcgp_deck_analyze
+COPY . /app/ptcgp_deck_analyze
 
 # 確保啟動腳本可以執行
 RUN chmod +x /app/ptcgp_deck_analyze/run.sh

--- a/ptcgp_deck_analyze/config.json
+++ b/ptcgp_deck_analyze/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Pokemon TCG Pocket Deck Analyzer",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "slug": "ptcgp_deck_analyze",
   "description": "分析 Pokemon TCG Pocket 牌組勝率的 Home Assistant Add-on",
   "startup": "once",

--- a/ptcgp_deck_analyze/config.json
+++ b/ptcgp_deck_analyze/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Pokemon TCG Pocket Deck Analyzer",
-  "version": "1.0.14",
+  "version": "1.0.16",
   "slug": "ptcgp_deck_analyze",
   "description": "分析 Pokemon TCG Pocket 牌組勝率的 Home Assistant Add-on",
   "startup": "once",


### PR DESCRIPTION
## Summary
- use Home Assistant base image to provide run.sh support
- bump addon version to 1.0.16

## Testing
- `python -m py_compile ptcgp_deck_analyze/scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_6840637e42208333b800b06a17f35548