### PR TITLE
更新 Dockerfile 安裝 bashio

### DIFF
--- a/ptcgp_deck_analyze/Dockerfile
+++ b/ptcgp_deck_analyze/Dockerfile
@@ -1,11 +1,17 @@
-ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.18
-FROM ${BUILD_FROM}
+FROM python:3.11-slim
 
-# 安裝 Python + 基本工具
-RUN apk add --no-cache python3 py3-pip
+# 安裝必要套件與編譯工具
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash curl wget gcc g++ make git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
-# 如果有像 pandas / numpy 這類需要編譯的套件，需要多裝這些編譯工具
-RUN apk add --no-cache gcc musl-dev libffi-dev python3-dev libc-dev make
+# 安裝 bashio 以讀取 Add-on 設定
+ENV BASHIO_VERSION=0.17.0
+RUN wget -q https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz -O /tmp/bashio.tar.gz \
+    && tar -xzf /tmp/bashio.tar.gz -C /tmp \
+    && mv /tmp/bashio-${BASHIO_VERSION}/lib /usr/lib/bashio \
+    && ln -s /usr/lib/bashio/bashio /usr/local/bin/bashio \
+    && rm -rf /tmp/bashio.tar.gz /tmp/bashio-${BASHIO_VERSION}
 
 # 你的其他前置檔案
 COPY requirements.txt /app/requirements.txt

--- a/ptcgp_deck_analyze/config.json
+++ b/ptcgp_deck_analyze/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Pokemon TCG Pocket Deck Analyzer",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "slug": "ptcgp_deck_analyze",
   "description": "分析 Pokemon TCG Pocket 牌組勝率的 Home Assistant Add-on",
   "startup": "once",

--- a/ptcgp_deck_analyze/run.sh
+++ b/ptcgp_deck_analyze/run.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/with-contenv bashio
+#!/usr/bin/env bash
+source /usr/lib/bashio/bashio.sh
 
 # 讀取 HA Add-on 中使用者設定的 key
 export OPENAI_API_KEY=$(bashio::config 'openai_api_key')


### PR DESCRIPTION
## Summary
- use `python:3.11-slim` as base image
- install bashio manually in Dockerfile
- update `run.sh` to source bashio
- bump add-on version

## Testing
- `python ptcgp_deck_analyze/scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_68416c695968833394703facc0b96e2e