### PR TITLE
Add scraped data output

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -466,6 +466,19 @@ def main():
     print("\n=== ChatGPT o3-mini 推論結果 ===")
     print(verdict)
 
+    # 5) Save scraped data to JSON file
+    result = {
+        'decks': df.to_dict('records'),
+        'matrix': matrix,
+        'verdict': verdict,
+    }
+    try:
+        with open('result.json', 'w', encoding='utf-8') as f:
+            json.dump(result, f, ensure_ascii=False, indent=2)
+        logging.info('已將資料寫入 result.json')
+    except Exception as e:
+        logging.error(f'寫入 result.json 失敗: {e}')
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- output scraped deck data, matchup matrix and ChatGPT verdict to `result.json`

## Testing
- `python scraper.py` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684abbeb743083339e610385073a0ba8